### PR TITLE
Added Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/http": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/http": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0|^7.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package dependencies to support version 11.0 of `illuminate/contracts`, `illuminate/http`, and `illuminate/support`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->